### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ whatever code matches.
 
 Return the XML::Element with the given id.
 
-#### getElementByTagName($name, :$object?)
+#### getElementsByTagName($name, :$object?)
 
 Return an array of XML::Elements with the given tag name.
 


### PR DESCRIPTION
getElementsByTagName was incorrectly written as getElementByTagName in the documentation