### PR TITLE
Set-wise operations on attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,48 @@ ignored entirely.
 Returns True if the given attribute exists, and has the same value
 as its name (the definition of an XML boolean.)
 
+#### add-values (Str $attrib, Set $values)
+
+For the attribute with the given _$name_, perform the set-wise union, _(|)_, 
+of the set of _$values_ passed to the method and the existing values of the attribute.
+The results are converted back to a string value and stored in the attribute. For example:
+
+```perl
+my $xml = from-xml('<test><folks we = "Al Barb Carl"/></test>');
+say $xml[0]; # <folks we="Al Barb Carl"/>
+
+$xml[0].add-values("we", <Carl Dave Ellie>.Set);
+say $xml[0]; # <folks we="Al Barb Carl Dave Ellie"/>
+```
+
+#### delete-values (Str $attrib, Set $values)
+
+For the attribute with the given _$name_, perform the set-wise difference, _(-)_, 
+of the  existing values of the attribute and the _$values_ passed to the method.
+The results are converted back to a string value and stored in the attribute. For example:
+
+```perl
+my $xml = from-xml('<test><folks we = "Al Barb Carl Dave Ellie"/></test>');
+say $xml[0]; # <folks we="Al Barb Carl Dave Ellie"/>
+
+$xml[0].delete-values("we", <Al Ellie Zack>.Set);
+say $xml[0]; # <folks we="Barb Carl Dave"/>
+```
+
+#### test-values (Str $attrib, @tests)
+
+For the attribute with the given _$name_, test each value in @tests for membership
+in the set of existing values of the attribute. Returns a hash that has the test values
+as keys and the boolean results of the membership test as values. For example:
+
+```perl
+my $xml = from-xml('<test><folks we = "Barb Carl Dave"/></test>');
+say $xml[0]; # <folks we="Barb Carl Dave"/>
+
+my %test-results = $xml[0].test-values("we", <Al Carl Zack>.Array);
+say %test-results; # "Al" => Bool::False, "Carl" => Bool::True, "Zack" => Bool::False
+```
+
 #### elements()
 
 Return all child XML::Elements.

--- a/lib/XML.pm6
+++ b/lib/XML.pm6
@@ -384,6 +384,34 @@ class XML::Element does XML::Node
     return %.attribs{$attrib}:exists && %.attribs{$attrib} eq $attrib;
   }
 
+# ck
+  method add-values (Str $attrib, Set $values) 
+  {
+    my $old_values = %.attribs{$attrib}.split(/\s+/).Set;
+    my $new_values = $old_values (|) $values;
+    %.attribs{$attrib} = $new_values.Str;
+  }
+
+# ck
+  method delete-values (Str $attrib, Set $values) 
+  {
+    my $old_values = %.attribs{$attrib}.split(/\s+/).Set;
+    my $new_values = $old_values (-) $values;
+    %.attribs{$attrib} = $new_values.Str;
+  }
+
+# ck
+  method test-values (Str $attrib, @tests) 
+  {
+    my $values = %.attribs{$attrib}.split(/\s+/).Set;
+    my %result;
+    for @tests -> $test 
+    {
+      %result{$test} = $test (elem) $values;
+    }
+    return %result;
+  }
+
   method insert-xml (Str $xml) {
     my $element = self.new($xml);
     self.insert: $element;


### PR DESCRIPTION
I have added the methods add-values, delete-values and test-values to XML::Element.
These methods support set-wise operations on attribute values.
These operations are useful when, for example, the attribute values are
type NMTOKENS rather than CDATA or for applications that like to treat
CDATA attribute values as white space separated list of values. The values
are still stored as strings.
I modified README.md to document the new methods.