### PR TITLE
Question mark and unit

### DIFF
--- a/lib/XML.pm6
+++ b/lib/XML.pm6
@@ -990,16 +990,16 @@ class XML::Document does XML::Node
       #$*ERR.say: "We parsed the doc";
       if ($doc<xmldecl>)
       {
-        $version = ~$doc<xmldecl>[0]<version><value>;
-        if ($doc<xmldecl>[0]<encoding>)
+        $version = ~$doc<xmldecl><version><value>;
+        if ($doc<xmldecl><encoding>)
         {
-          $encoding = ~$doc<xmldecl>[0]<encoding>[0]<value>;
+          $encoding = ~$doc<xmldecl><encoding><value>;
         }
       }
       if ($doc<doctypedecl>)
       {
-        %doctype<type> = ~$doc<doctypedecl>[0]<name>;
-        %doctype<value> = ~$doc<doctypedecl>[0]<content>;
+        %doctype<type> = ~$doc<doctypedecl><name>;
+        %doctype<value> = ~$doc<doctypedecl><content>;
       }
       $root = XML::Element.parse-node($doc<root>);
       my $this = self.new(:$version, :$encoding, :%doctype, :$root, :$filename);

--- a/lib/XML/Grammar.pm6
+++ b/lib/XML/Grammar.pm6
@@ -1,4 +1,4 @@
-grammar XML::Grammar;
+unit grammar XML::Grammar;
 
 rule TOP {
   ^


### PR DESCRIPTION
the "?" quantifier in regex used to give you a list of either 0 or 1 element, now it gives either Nil or a match object.

this fixes a "use of nil in string context" warning in the tests

also, we require "unit" to be put in front of semicolon forms of grammar, class, module etc.

this fixes a deprecation warning