### PR TITLE
Add a lookfor method, a shortcut for elements(...,:RECURSE<Inf>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ whatever code matches.
 
 ```
 
+#### lookfor(...)
+
+A shortcut for elements(..., :RECURSE)
+
 #### getElementById($id)
 
 Return the XML::Element with the given id.

--- a/lib/XML.pm6
+++ b/lib/XML.pm6
@@ -568,6 +568,10 @@ class XML::Element does XML::Node
   #              position index (starts with 0) rather than the user idea of
   #              odd and even elements (starting with 1.)
   #
+  
+  method lookfor(*%query) {
+    return self.elements(:RECURSE, |%query);
+  }
   method elements (*%query)
   {
     my $recurse = 0;
@@ -952,7 +956,7 @@ class XML::Document does XML::Node
   has $.encoding;
   has %.doctype;
   has $.root handles <
-    attribs nodes elements getElementById getElementsByTagName
+    attribs nodes elements lookfor getElementById getElementsByTagName
     nsURI nsPrefix setNamespace
     append insert set unset before after
     appendNode insertNode insertBefore insertAfter

--- a/t/query-methods.t
+++ b/t/query-methods.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 26;
+plan 27;
 
 my $text = slurp('./t/query.xml');
 
@@ -79,5 +79,9 @@ is $subxml, '<test><item name="first"/><item name="second"/></test>',
   'object query returned proper XML output.';
 
 $subxml = $xml.elements(:TAG<a>, :RECURSE, :SINGLE);
-ok $subxml ~~ XML::Element, "found the an element with elements(:TAG<a>,:RECURSE)";
+ok $subxml ~~ XML::Element, "found an element with elements(:TAG<a>,:RECURSE, :SINGLE)";
 ok $subxml.name eq "a", "The returned element is <a>";
+
+$subxml = $xml.lookfor(:TAG<a>, :SINGLE);
+ok $subxml ~~ XML::Element, "found an element with lookfor(:TAG<a>, :SINGLE)";
+


### PR DESCRIPTION
Probably not that useful, but it make writing searching elements in a tree build from html less annoying because some webpages can have a lot of nested `<div>`

`my @storydiv = $innerdiv.lookfor(:TAG<div>, :class<story_content_box>);`

vs 

`my @storydiv = $innerdiv.elements(:TAG<div>, :class<story_content_box>, :RECURSE);`

