### PR TITLE
Remove mentions of @*INC, which no longer exists in Perl 6

### DIFF
--- a/t/emitter.t
+++ b/t/emitter.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/example.t
+++ b/t/example.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use XML;
 use Test;

--- a/t/namespaces.t
+++ b/t/namespaces.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/parser.t
+++ b/t/parser.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/preamble.t
+++ b/t/preamble.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/proxies.t
+++ b/t/proxies.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/query-methods.t
+++ b/t/query-methods.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;

--- a/t/query-positional.t
+++ b/t/query-positional.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use Test;
 use XML;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
(I realize those are all commented out... still)