### PR TITLE
Improve coverage of allowed XML Names

### DIFF
--- a/lib/XML/Grammar.pm6
+++ b/lib/XML/Grammar.pm6
@@ -92,7 +92,6 @@ regex cdata {
 
 token textnode { <-[<]>+ }
 token pident {
-  | <.ident>
-  | '-'
+  <!before \d> [ \d+ <.ident>* || <.ident>+ ]+ % '-'
 }
 token name { <.pident>+ [ ':' <.pident>+ ]? }

--- a/t/parser.t
+++ b/t/parser.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 12;
+plan 13;
 
 my $text = '<test><title>The title</title><bullocks><item name="first"/><item name="second"/></bullocks></test>';
 
@@ -42,3 +42,7 @@ is $xml.root.attribs<attr1>, 'foo', 'got single-quoted attribute';
 
 lives-ok { from-xml('<foo><bar id1-1paté="bat" /></foo>') }, 'valid attribute name';
 dies-ok  { from-xml('<foo><bar 2d="bar" /></foo>') }, 'invalid attribute name';
+
+my $numdoc = from-xml('<foo><bar-1>baz</bar-1></foo>');
+
+is $numdoc.root[0].name, 'bar-1', 'parsed tag name with number';

--- a/t/parser.t
+++ b/t/parser.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 10;
+plan 12;
 
 my $text = '<test><title>The title</title><bullocks><item name="first"/><item name="second"/></bullocks></test>';
 
@@ -37,3 +37,8 @@ is $xml, $head~$text, 'parsed back after unset';
 $text = "<elem attr1='foo' attr2='bar'></elem>";
 $xml = from-xml($text);
 is $xml.root.attribs<attr1>, 'foo', 'got single-quoted attribute';
+
+# Test available identifiers.
+
+lives-ok { from-xml('<foo><bar id1-1paté="bat" /></foo>') }, 'valid attribute name';
+dies-ok  { from-xml('<foo><bar 2d="bar" /></foo>') }, 'invalid attribute name';


### PR DESCRIPTION
Found that some of the W3C test suites have numbers after dashes.