### PR TITLE
Fix nsPrefix

### DIFF
--- a/lib/XML/Element.pm6
+++ b/lib/XML/Element.pm6
@@ -544,9 +544,9 @@ class XML::Element does XML::Node
             if $key eq 'URI'
             {
               $prefix = $node.nsPrefix($val);
-          if !$prefix.defined() { $matched = False; last; }
+              if !$prefix.defined() { $matched = False; last; }
             }
-            if $prefix eq ''
+            if $prefix.defined && $prefix eq ''
             {
               if $node.name ~~ / ':' / { $matched = False; last; }
             }
@@ -658,9 +658,9 @@ class XML::Element does XML::Node
   {
     for $.attribs.kv -> $key, $val
     {
-      if $val eq $uri && $key.match(/^xmlns(\:||$) <( .* )>/)
+      if $val eq $uri && $key.match(/^xmlns(\:||$) <( .* )>/) -> $prefix
       {
-        return $/;
+        return ~$prefix;
       }
     }
     return $.parent.isa(XML::Element) ?? $.parent.nsPrefix($uri) !! Nil;


### PR DESCRIPTION
The $/ from the outer match isn't being implicitly passed into the
if block, providing the result as an explicit parameter fixes

I think it actually may be more complicated than that, being something to do with the scope of the $/ and returning it from the sub but this should be proof against further changes when we only went to return the string of the prefix anyway.