### PR TITLE
Fix incorrect type constraint

### DIFF
--- a/lib/XML.pm6
+++ b/lib/XML.pm6
@@ -9,7 +9,7 @@ module XML
     return XML::Document.new($xml-string);
   }
 
-  sub from-xml-stream (IO $input) is export
+  sub from-xml-stream (IO::Handle $input) is export
   {
     return XML::Document.new($input.slurp-rest);
   }


### PR DESCRIPTION
IO role used to accept IO::Path and IO::Socket* types, none of which have a .slurp-rest method.
Also, role IO has been removed, as it hasn't really been part of the language... or ever useful.