### PR TITLE
Bump version and use new META file name

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "XML",
-  "version"     : "0.0.2",
+  "version"     : "0.0.3",
   "description" : "A full-featured, pure-perl XML library (parsing, manipulation, emitting, queries, etc.)",
   "author"      : "Timothy Totten",
   "depends"     : [ ],


### PR DESCRIPTION
- Bump version so users get all the latest updates (Fixes #44)
- Rename meta file to META6.json. This is the new name that's been
    in use since Dec 2015. META.info is the old legacy name.