### PR TITLE
Problem when there are quotes in strings of attributes 

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,7 @@
   "description" : "A full-featured, pure-perl XML library (parsing, manipulation, emitting, queries, etc.)",
   "author"      : "Timothy Totten",
   "license"     : "Artistic-2.0",
-  "depends"     : [ ],
+  "depends"     : [ "HTML::Escape" ],
   "provides"    : {
     "XML"          : "lib/XML.pm6",
     "XML::CDATA"   : "lib/XML/CDATA.pm6",

--- a/lib/XML/Element.pm6
+++ b/lib/XML/Element.pm6
@@ -4,6 +4,8 @@ use XML::Comment;
 use XML::PI;
 use XML::CDATA;
 
+use HTML::Escape;
+
 class XML::Element does XML::Node
 {
   use XML::Grammar;
@@ -755,7 +757,8 @@ class XML::Element does XML::Node
     my $element = '<' ~ $.name;
     for %.attribs.kv -> $key, $val
     {
-      $element ~= " $key=\"$val\"";
+      my Str:D $val_escaped = escape-html($val);
+      $element ~= " $key=\"$val_escaped\"";
     }
     if (@.nodes)
     {

--- a/t/quotes.t
+++ b/t/quotes.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl6
+
+use Test;
+use XML;
+
+plan 1;
+
+my $xml1 = from-xml('<test ATTRIB="&quot;text&quot;"></test>');
+
+lives-ok { from-xml($xml1.Str) };


### PR DESCRIPTION
Hi!

First I made a test which shows what the problem is about in ```t/quotes.t```. 
After that I made a solution to that problem. A downside with the solution is that it relies on ```HTML::Escape```, however some kinds functionality like that is needed if both single and double quoted strings should be allowed, if I understood it correctly. Ref: https://www.w3schools.com/XML/xml_attributes.asp

