### PR TITLE
Fix possibility to write through proxies {} and []

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "XML",
-  "version"     : "0.0.3",
+  "version"     : "0.0.4",
   "description" : "A full-featured, pure-perl XML library (parsing, manipulation, emitting, queries, etc.)",
   "author"      : "Timothy Totten",
   "license"     : "Artistic-2.0",

--- a/lib/XML/Document.pm6
+++ b/lib/XML/Document.pm6
@@ -28,12 +28,12 @@ class XML::Document does XML::Node
     return $clone;
   }
 
-  method AT-POS ($offset)
+  method AT-POS ($offset) is rw
   {
     $.root[$offset];
   }
 
-  method AT-KEY ($offset)
+  method AT-KEY ($offset) is rw
   {
     $.root{$offset};
   }

--- a/lib/XML/Element.pm6
+++ b/lib/XML/Element.pm6
@@ -786,7 +786,7 @@ class XML::Element does XML::Node
     return $element;
   }
 
-  method AT-POS ($offset)
+  method AT-POS ($offset) is rw
   {
     my $self = self;
     Proxy.new(
@@ -801,7 +801,7 @@ class XML::Element does XML::Node
     );
   }
 
-  method AT-KEY ($offset)
+  method AT-KEY ($offset) is rw
   {
     my $self = self;
     Proxy.new(

--- a/t/proxies.t
+++ b/t/proxies.t
@@ -5,7 +5,7 @@
 use Test;
 use XML;
 
-plan 7;
+plan 11;
 
 my $doc = from-xml-file('./t/query.xml');
 
@@ -19,8 +19,14 @@ is $xml[3][1]<name>, 'first', 'Postcircumfix lookup of Attribute works.';
 is $doc.nodes[1].nodes[0].string, 'The title', '.nodes on doc works';
 is $doc[3][3]<name>, 'second', 'Postcircumfix [] on doc works.';
 
-$doc<id> = 'default';
+lives-ok { $doc<id> = 'default' }, 'Write through postcircumfix {}';
 
 is $xml.attribs<id>, 'default', 'Postcircumfix {} on doc works.';
 
 is $doc.attribs<id>, 'default', '.attribs on doc works.';
+
+lives-ok { $doc[1] = XML::Text.new(:text("The new title")) }, 'Write through postcircumfix []';
+
+is $xml.nodes[1].string, "The new title", 'Postcircumfix [] on doc works after write.';
+
+is $doc.nodes[1].string, "The new title", '.nodes on doc works after write.';


### PR DESCRIPTION
There is a fail test on modern versions of Perl 6:
```
===> Testing: XML:ver<0.0.3>:auth<Timothy Totten>
Cannot modify an immutable Any ((Any))
  in block <unit> at t/proxies.t line 22

# Looks like you planned 7 tests, but ran 5
===> Testing [FAIL]: XML:ver<0.0.3>:auth<Timothy Totten>
```

I have added `is rw` on corresponding `AT-KEY` and `AT-POS` methods to make `Proxy` be mutable.