### PR TITLE
Only remove old parent if it exists for the Node

### DIFF
--- a/lib/XML/Node.pm6
+++ b/lib/XML/Node.pm6
@@ -45,7 +45,7 @@ role XML::Node
 
   method reparent (::(q<XML::Element>) $parent)
   {
-    self.remove;
+    self.remove if $.parent.defined;
     $.parent = $parent;
     return self;
   }


### PR DESCRIPTION
This actually makes me gain 10% speed on my Gumbo benchmark (creating over 11k XML::Elements)